### PR TITLE
chore: Remove scheduled generation of API client

### DIFF
--- a/.github/workflows/gen-client.yml
+++ b/.github/workflows/gen-client.yml
@@ -1,7 +1,5 @@
 name: Generate API Client
 on:
-  schedule:
-    - cron: '0 8 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
We should only trigger the code gen for the API Go client when we actually deploy the backend API otherwise the Go client can use a newer version of the API from the one deployed