### PR TITLE
feat: Remove title ordinal position

### DIFF
--- a/models.gen.go
+++ b/models.gen.go
@@ -303,12 +303,6 @@ type PluginDocsPage struct {
 
 	// Name The unique name for the plugin documentation page.
 	Name PluginDocsPageName `json:"name"`
-
-	// OrdinalPosition The position of the page in the documentation
-	OrdinalPosition *int `json:"ordinal_position,omitempty"`
-
-	// Title The title of the documentation page
-	Title string `json:"title"`
 }
 
 // PluginDocsPageCreate CloudQuery Plugin Documentation Page
@@ -318,12 +312,6 @@ type PluginDocsPageCreate struct {
 
 	// Name The unique name for the plugin documentation page.
 	Name PluginDocsPageName `json:"name"`
-
-	// OrdinalPosition The position of the page in the documentation
-	OrdinalPosition *int `json:"ordinal_position,omitempty"`
-
-	// Title The title of the documentation page
-	Title string `json:"title"`
 }
 
 // PluginDocsPageName The unique name for the plugin documentation page.

--- a/spec.json
+++ b/spec.json
@@ -3095,7 +3095,7 @@
       "PluginDocsPageName": {
         "description": "The unique name for the plugin documentation page.",
         "maxLength": 255,
-        "pattern": "^[a-z](-?[a-z0-9]+)+$",
+        "pattern": "^[\\w,\\s-]+$",
         "type": "string",
         "example": "overview"
       },
@@ -3104,22 +3104,11 @@
         "description": "CloudQuery Plugin Documentation Page",
         "required": [
           "name",
-          "title",
           "content"
         ],
         "properties": {
           "name": {
             "$ref": "#/components/schemas/PluginDocsPageName"
-          },
-          "title": {
-            "type": "string",
-            "description": "The title of the documentation page",
-            "example": "Getting Started"
-          },
-          "ordinal_position": {
-            "type": "integer",
-            "description": "The position of the page in the documentation",
-            "example": 1
           },
           "content": {
             "type": "string",
@@ -3135,22 +3124,11 @@
         "description": "CloudQuery Plugin Documentation Page",
         "required": [
           "name",
-          "title",
           "content"
         ],
         "properties": {
           "name": {
             "$ref": "#/components/schemas/PluginDocsPageName"
-          },
-          "title": {
-            "type": "string",
-            "description": "The title of the documentation page",
-            "example": "Getting Started"
-          },
-          "ordinal_position": {
-            "type": "integer",
-            "description": "The position of the page in the documentation",
-            "example": 1
           },
           "content": {
             "type": "string",


### PR DESCRIPTION
Opening for reference. While working on https://github.com/cloudquery/cloud/issues/457 I realized we don't need some fields in the Docs API so I removed them, opening for reference