### PR TITLE
chore: Remove `-tags=assert` test tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: test
 test:
-	go test -tags=assert -race ./...
+	go test -race ./...
 
 .PHONY: lint
 lint:


### PR DESCRIPTION
These tags are required for arrow based tests - which are needed in this project

refs: https://github.com/cloudquery/cloudquery-issues/issues/668
