### PR TITLE
feat: Add a `Token` struct to allow the CLI to differentiate between `Bearer` and `APIKey` tokens

### DIFF
--- a/auth/token_test.go
+++ b/auth/token_test.go
@@ -46,7 +46,7 @@ func TestTokenClient_EnvironmentVariable(t *testing.T) {
 	token, err := NewTokenClient().GetToken()
 	require.NoError(t, err)
 
-	require.Equal(t, "my_token", token)
+	require.Equal(t, Token{Type: APIKey, Value: "my_token"}, token)
 }
 
 func TestTokenClient_GetToken_ShortExpiry(t *testing.T) {
@@ -66,13 +66,13 @@ func TestTokenClient_GetToken_ShortExpiry(t *testing.T) {
 
 	token, err := tc.GetToken()
 	require.NoError(t, err)
-	require.Equal(t, "my_id_token_0", token, "first token")
+	require.Equal(t, Token{Type: BearerToken, Value: "my_id_token_0"}, token, "first token")
 
 	tc.expiresAt = t0
 
 	token, err = tc.GetToken()
 	require.NoError(t, err)
-	require.Equal(t, "my_id_token_1", token, "expected to issue new token")
+	require.Equal(t, Token{Type: BearerToken, Value: "my_id_token_1"}, token, "expected to issue new token")
 }
 
 func TestTokenClient_GetToken_LongExpiry(t *testing.T) {
@@ -89,11 +89,11 @@ func TestTokenClient_GetToken_LongExpiry(t *testing.T) {
 
 	token, err := tc.GetToken()
 	require.NoError(t, err)
-	require.Equal(t, "my_id_token_0", token, "first token")
+	require.Equal(t, Token{Type: BearerToken, Value: "my_id_token_0"}, token, "first token")
 
 	token, err = tc.GetToken()
 	require.NoError(t, err)
-	require.Equal(t, "my_id_token_0", token, "expected to reuse token")
+	require.Equal(t, Token{Type: BearerToken, Value: "my_id_token_0"}, token, "expected to reuse token")
 }
 
 func overrideEnvironmentVariable(t *testing.T, key, value string) func() {


### PR DESCRIPTION
This PR adds a `Token` struct to allow the CLI to differentiate between the auth methods.

The CLI will have a different download flow depending on if the auth is using a bearer token vs an API key. For the bearer token the `team_name` is configured using the `cloudquery switch` command. For the API key, the key is associated with a team name already.
