### PR TITLE
feat: Add method to return token type

### DIFF
--- a/auth/token.go
+++ b/auth/token.go
@@ -66,8 +66,8 @@ func NewTokenClient() *TokenClient {
 // GetToken returns the ID token
 // If CLOUDQUERY_API_KEY is set, it returns that value, otherwise it returns an ID token generated from the refresh token.
 func (tc *TokenClient) GetToken() (Token, error) {
-	if token := os.Getenv(EnvVarCloudQueryAPIKey); token != "" {
-		return Token{Type: APIKey, Value: token}, nil
+	if tc.GetTokenType() == APIKey {
+		return Token{Type: APIKey, Value: os.Getenv(EnvVarCloudQueryAPIKey)}, nil
 	}
 
 	// If the token is not expired, return it
@@ -96,6 +96,14 @@ func (tc *TokenClient) GetToken() (Token, error) {
 	}
 
 	return Token{Type: BearerToken, Value: tc.idToken}, nil
+}
+
+// GetTokenType returns the type of token that will be returned by GetToken
+func (tc *TokenClient) GetTokenType() TokenType {
+	if token := os.Getenv(EnvVarCloudQueryAPIKey); token != "" {
+		return APIKey
+	}
+	return BearerToken
 }
 
 func (tc *TokenClient) generateToken(refreshToken string) (*tokenResponse, error) {

--- a/auth/token_test.go
+++ b/auth/token_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -101,6 +102,20 @@ func TestTokenClient_GetToken_LongExpiry(t *testing.T) {
 	token, err = tc.GetToken()
 	require.NoError(t, err)
 	require.Equal(t, Token{Type: BearerToken, Value: "my_id_token_0"}, token, "expected to reuse token")
+}
+
+func TestTokenClient_BearerTokenType(t *testing.T) {
+	tc := NewTokenClient()
+
+	assert.Equal(t, BearerToken, tc.GetTokenType())
+}
+
+func TestTokenClient_APIKeyTokenType(t *testing.T) {
+	t.Setenv(EnvVarCloudQueryAPIKey, "my_token")
+
+	tc := NewTokenClient()
+
+	assert.Equal(t, APIKey, tc.GetTokenType())
 }
 
 func overrideEnvironmentVariable(t *testing.T, key, value string) func() {


### PR DESCRIPTION
Whilst the token itself now contains the token type, it is useful to be able to determine the type of tokens the token client will return without fetching a token first. An example user of this functionality will be the usage client, which needs to determine if an API call is needed to fetch the team name when the authentication is using an API key.

Refs: https://github.com/cloudquery/cloudquery-issues/issues/893
