### PR TITLE
fix: Better error on expired token

### DIFF
--- a/auth/token_error.go
+++ b/auth/token_error.go
@@ -1,0 +1,39 @@
+package auth
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+type TokenError struct {
+	Body         []byte `json:"-"`
+	ErrorDetails struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+		Status  string `json:"status"`
+	} `json:"error"`
+}
+
+func (t TokenError) Error() string {
+	return string(t.Body)
+}
+
+func TokenErrorFromBody(body []byte) *TokenError {
+	t := &TokenError{}
+	_ = json.Unmarshal(body, t)
+	t.Body = body
+	return t
+}
+
+func IsTokenExpiredError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var te *TokenError
+	if errors.As(err, &te) {
+		return te.ErrorDetails.Code == 400 && te.ErrorDetails.Message == "TOKEN_EXPIRED"
+	}
+
+	return false
+}


### PR DESCRIPTION
Previously:
```
Error: failed to get auth token: failed to sign in with custom token: failed to refresh token: 400 Bad Request: {
  "error": {
    "code": 400,
    "message": "TOKEN_EXPIRED",
    "status": "INVALID_ARGUMENT"
  }
}

exit status 1
```

Now:
```
Error: failed to get auth token: authentication token expired: failed to refresh token: 400 Bad Request: {
  "error": {
    "code": 400,
    "message": "TOKEN_EXPIRED",
    "status": "INVALID_ARGUMENT"
  }
}
. Hint: You may need to run `cloudquery login` or set CLOUDQUERY_API_KEY
exit status 1
```