### PR TITLE
chore: Switch to `googleapis/release-please-action`

### DIFF
--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: googleapis/release-please-action@v3
         id: release
         with:
           release-type: go


### PR DESCRIPTION
Part of https://github.com/cloudquery/cloudquery-issues/issues/1985 (internal issue).
`google-github-actions/release-please-action` was archived and moved to `googleapis/release-please-action`