### PR TITLE
feat: add team_internal config key

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,7 @@ const configPath = "cloudquery/config.json"
 
 var configKeys = []string{
 	"team",
+	"team_internal",
 }
 
 // SetConfigHome sets the configuration home directory - useful for testing


### PR DESCRIPTION
This adds a `team_internal` config key to be used to store if the current team is CloudQuery-internal.