### PR TITLE
chore: Create CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+*       @cloudquery/cloudquery-framework
+
+go.mod
+go.sum


### PR DESCRIPTION
This client is mostly used in the CLI hence data framework team as the owner